### PR TITLE
Add 'grunt serve' tooling to watch while serving

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,15 +35,17 @@ module.exports = function(grunt) {
     },
     watch: {
       all: {
-        files: ['src/js/*.js', 'src/sass/*.scss'],
+        files: ['src/js/*.js', 'src/sass/*.scss', 'app/index.html'],
         tasks: ['js', 'css'],
+        options: { livereload: true },
       }
     },
     connect: {
       server: {
         options: {
           base: 'app',
-          livereload: true
+          livereload: true,
+          open: true,
         }
       }
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,9 +23,9 @@ module.exports = function(grunt) {
         }
       }
     },
-    sass: {                              
-      dist: {                            
-        options: {                       
+    sass: {
+      dist: {
+        options: {
           style: 'compressed'
         },
         files: {
@@ -39,6 +39,14 @@ module.exports = function(grunt) {
         tasks: ['js', 'css'],
       }
     },
+    connect: {
+      server: {
+        options: {
+          base: 'app',
+          livereload: true
+        }
+      }
+    }
   });
 
   // Loading tasks.
@@ -48,13 +56,15 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-wiredep');
+  grunt.loadNpmTasks('grunt-contrib-connect');
 
-  // Tasks.  
+
+  // Tasks.
   grunt.registerTask('default', ['build']);
   grunt.registerTask('js', ['jshint', 'uglify']);
   grunt.registerTask('build', ['wiredep', 'js', 'css', 'watch']);
   grunt.registerTask('bower', ['wiredep'])
   grunt.registerTask('css',['sass']);
   grunt.registerTask('lint', ['jshint']);
-
+  grunt.registerTask('serve', ['connect:server', 'watch']);
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "browserify": "2.35.4",
+    "goat": "^0.4.2",
     "grunt": "^0.4.5",
     "grunt-browserify": "1.2.x",
     "grunt-contrib-clean": "0.5.x",
@@ -23,9 +24,8 @@
     "grunt-contrib-jshint": "0.7.0",
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "^0.8.0",
-    "grunt-contrib-watch": "0.5.x",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-reload": "^0.2.0",
-    "grunt-wiredep": "^2.0.0",
-    "goat": "^0.4.2"
+    "grunt-wiredep": "^2.0.0"
   }
 }


### PR DESCRIPTION
By running `grunt serve`, a developer can start a server that runs `grunt watch` simultaneously with `grunt connect`.  Additionally, when `grunt serve` begins, a browser will open automatically.  Browser will reload on file changes.