### PR TITLE
Reorg to place main component wiring in L.DNC.js

### DIFF
--- a/src/js/L.DNC.js
+++ b/src/js/L.DNC.js
@@ -11,7 +11,22 @@
         window.L.DNC = DNC;
 
         L.DNC.init = function(){
-            L.DNC.mapView = new L.DNC.MapView();
+
+            this.mapView = new L.DNC.MapView();
+            this.dropzone = new L.DNC.DropZone( this.mapView._map, {} );
+            this.layerlist = new L.DNC.LayerList( { layerContainerId: 'dropzone' } ).addTo( this.mapView._map );
+            this.geoMenu = new L.DNC.Menu( this.layerlist, {} );
+
+            // examples of events that L.DNC.DropZone.FileReader throws
+            this.dropzone.fileReader.on( "fileparsed", function(e){
+                // TODO: This should be refactored so that this.dropzone and
+                // this.layerlist are not so tightly coupled. The logic behind
+                // this tooling should exist within their respective modules.
+                console.debug( "[ FILEREADER ]: file parsed > ", e.file );
+                var mapLayer = L.mapbox.featureLayer(e.file);
+                this.layerlist.addLayerToList( mapLayer, e.fileInfo.name, true );
+                this.numLayers++;
+            }.bind(this));
         };
     }
 })();

--- a/src/js/dropzone/DropZone.js
+++ b/src/js/dropzone/DropZone.js
@@ -19,6 +19,7 @@ L.DNC.DropZone = L.Class.extend({
         this.type = L.DNC.DropZone.TYPE;
 
         this.fileReader = new L.DNC.DropZone.FileReader( this._map, options );
+        this.fileReader.enable();
     }
 
 });

--- a/src/js/dropzone/handlers/DropZone.FileReader.js
+++ b/src/js/dropzone/handlers/DropZone.FileReader.js
@@ -13,7 +13,13 @@ L.DNC.DropZone.FileReader = L.Handler.extend({
         L.setOptions(this, options);
         this._map = map;
         this._container = map._container;
+        this._registerEventHandlers();
+    },
 
+    _registerEventHandlers: function() {
+        this.on( "enabled", function(e){
+            console.debug( "[ FILEREADER ]: enabled > ", e );
+        });
     },
 
     enable: function () {

--- a/src/js/mapview/MapView.js
+++ b/src/js/mapview/MapView.js
@@ -15,11 +15,9 @@ L.DNC.MapView = L.Class.extend({
 
         this.numLayers = 0;
         this._map = null;
-        this.download = document.getElementById('download');
 
         // init hooks
         this._setupMap();
-        this._registerEventHandlers();
 
     } ,
 
@@ -31,36 +29,6 @@ L.DNC.MapView = L.Class.extend({
             zoomControl: false
         }).setView([0,0], 3);
 
-    } ,
-
-    updateDownload : function(file) {
-        download.href = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(file));
-    } ,
-
-    _registerEventHandlers: function(){
-
-        // wire L.DNC plugins
-        this.dropzone = new L.DNC.DropZone( this._map, {} );
-        this.layerlist = new L.DNC.LayerList( { layerContainerId: 'dropzone' }).addTo( this._map );
-        this.geoMenu = new L.DNC.Menu( this.layerlist, {} );
-
-        // examples of events that L.DNC.DropZone.FileReader throws
-        this.dropzone.fileReader.on( "enabled", function(e){
-            console.debug( "[ FILEREADER ]: enabled > ", e );
-        });
-        this.dropzone.fileReader.on( "fileparsed", function(e){
-            console.debug( "[ FILEREADER ]: file parsed > ", e.file );
-            var mapLayer = L.mapbox.featureLayer(e.file);
-            this.layerlist.addLayerToList( mapLayer, e.fileInfo.name, true );
-            this.numLayers++;
-        }.bind(this));
-
-        this.dropzone.fileReader.enable();
     }
 
-
-
 });
-
-
-


### PR DESCRIPTION
Previously, a huge chunk of the app's initialization took place in `L.DNC.MapView._registerEventHandlers()`, which felt a bit strange.  In effort to keep things modular and avoid interdependency, this wiring was moved in `L.DNC.init`, which seems to be an appropriate place to tie everything together.