### PR TITLE
Adding in an option, defaulting to on, that zooms the map to fit new layers when added

### DIFF
--- a/src/js/layerlist/LayerList.js
+++ b/src/js/layerlist/LayerList.js
@@ -108,7 +108,7 @@ L.DNC.LayerList = L.Control.extend({
             for (var i in this._layers) {
                 bounds.extend(this._layers[i].layer.getBounds());
             }
-            this._map.fitBounds(bounds)
+            this._map.fitBounds(bounds);
         }
 
     },

--- a/src/js/layerlist/LayerList.js
+++ b/src/js/layerlist/LayerList.js
@@ -14,6 +14,7 @@ L.DNC.LayerList = L.Control.extend({
     // defaults
     options: {
         autoZIndex: true,
+        zoomToExtentOnAdd: true,
         layerContainerId: 'dropzone'
     },
 
@@ -98,6 +99,18 @@ L.DNC.LayerList = L.Control.extend({
         }
 
         this._update();
+
+        // If we have the zoomToExtentOnAdd feature enabled (on by default, but can be
+        // hooked to UI element) then we loop through the layers and get the extent and 
+        // set the map zoom so people see the data right away.
+        if (this.options.zoomToExtentOnAdd) {
+            var bounds = layer.getBounds();
+            for (var i in this._layers) {
+                bounds.extend(this._layers[i].layer.getBounds());
+            }
+            this._map.fitBounds(bounds)
+        }
+
     },
 
     removeLayerFromList: function (layer) {


### PR DESCRIPTION
Hey there folks.  Just checking out the new project... way cool.  While I was in checking it out I thought I would try to add something to get my feet wet.  Simple change to loop through all layers when a new layer is added and come up with a bounds for all the data and zoom the map to it.  This makes adding data much more pleasant  as you instantly see all your data.  It is an option (defaulting to on) that can be tied to a UI element in the future if you wanted to make it an option (since auto zoom in some special cases might not be desired).  In general though, I imagine that the 99% of cases will like having the map auto zoom to an extent to see all data when new layers are added.

Feel free to reject as well... just playing around tonight and thought I would kick the tires :-) 