### PR TITLE
Move initialization into L.DNC.js, normalize object apis

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
     },
     concat: {
         dist: {
-          src: ['src/js/*.js', 'src/js/menu/Menu.js', 'src/js/**/*.js'],
+          src: ['src/js/*.js', 'src/js/menu/MenuBar.js', 'src/js/**/*.js'],
           dest: 'dist/js/L.DNC.js'
         },
     },

--- a/src/js/L.DNC.js
+++ b/src/js/L.DNC.js
@@ -14,8 +14,24 @@
 
             this.mapView = new L.DNC.MapView();
             this.dropzone = new L.DNC.DropZone( this.mapView._map, {} );
-            this.layerlist = new L.DNC.LayerList( { layerContainerId: 'dropzone' } ).addTo( this.mapView._map );
-            this.menuBar = new L.DNC.MenuBar( this.layerlist, {} );
+            this.layerlist = new L.DNC.LayerList( { layerContainerId: 'dropzone' } )
+                .addTo( this.mapView._map );
+            this.menuBar = new L.DNC.MenuBar()
+                .addTo( document.getElementById('menu-bar') )
+                .addChild( new L.DNC.Menu( "Geoprocessing Tools", {} )
+                    .addChild(new L.DNC.TurfOperation('buffer', {
+                        maxFeatures: 1,
+                        additionalArgs: 0.1
+                    }))
+                    .addChild(new L.DNC.TurfOperation('union', {
+                        minFeatures: 2,
+                        maxFeatures: 2
+                    }))
+                    .addChild(new L.DNC.TurfOperation('erase', {
+                        minFeatures: 2,
+                        maxFeatures: 2
+                    }))
+                );
         };
     }
 })();

--- a/src/js/menu/Menu.js
+++ b/src/js/menu/Menu.js
@@ -1,26 +1,24 @@
 L.DNC = L.DNC || {};
-L.DNC.Menu = L.Class.extend({ // This is a base class. It should never be initiated directly.
-
-    // defaults
-    options: {
-        parentId : 'menu-bar'
-    },
+L.DNC.Menu = L.DNC.MenuBar.extend({
 
     initialize: function ( title, options ) {
         L.setOptions(this, options);
-
         this.title = title;
-
-        this.domElement = this._buildMenu();
+        this.children = [];
+        this.domElement = this._buildDomElement();
         this._addEventHandlers();
     },
 
+    // Add object as child. Object must have domElement property.
+    addChild: function( child ) {
+        var dropdown = this.domElement.getElementsByClassName('menu-dropdown')[0];
+        dropdown.appendChild( child.domElement );
+        this.children.push( child );
+        return this;
+    },
+
+    // handlers for menu options
     _addEventHandlers : function () {
-        /*
-        **
-        **  handlers for menu options
-        **
-        */
         if (this.domElement) {
             this.domElement.addEventListener('click', menuClick, false);
         }
@@ -46,23 +44,14 @@ L.DNC.Menu = L.Class.extend({ // This is a base class. It should never be initia
         }
     },
 
-    // Create and attach dom elements
-    _buildMenu: function () {
+    // Create and return dom element (note: this does not attach dom element to any parent)
+    _buildDomElement: function () {
         var menu = document.createElement('div');
         menu.className = "menu";
         menu.innerHTML = '<button class="menu-button">' +
             this.title + '<i class="fa fa-angle-down"></i>' +
             '</button>' +
         '<div class="menu-dropdown menu-expand"></div>';
-
-        var domElement = document.getElementById(this.options.parentId).appendChild(menu);
-        return domElement;
-    },
-
-    // Add operation to menu
-    addOperation: function( operation ) {
-        var dropdown = this.domElement.getElementsByClassName('menu-dropdown')[0];
-        dropdown.appendChild( operation.domElement );
-        return this;
+        return menu;
     }
 });

--- a/src/js/menu/MenuBar.js
+++ b/src/js/menu/MenuBar.js
@@ -1,32 +1,29 @@
 L.DNC = L.DNC || {};
 L.DNC.MenuBar = L.Class.extend({
 
-    // defaults
-    options: {
-        parentId : 'menu-bar'
+    initialize: function ( options ) {
+        L.setOptions(this, options);
+        this.children = [];
+        this.domElement = this._buildDomElement();
     },
 
-    initialize: function ( layerlist, options ) {
-        // override defaults with passed options
-        this.layerlist = layerlist;
-        L.setOptions(this, options);
+    // Add object as child. Object must have domElement property.
+    addChild: function ( child ) {
+        this.domElement.appendChild(child.domElement);
+        child.parentDomElement = this;
+        this.children.push( child );
+        return this;
+    },
 
-        var geotools = new L.DNC.Menu( "Geoprocessing Tools", {} )
-            .addOperation(new L.DNC.TurfOperation('buffer', {
-                maxFeatures: 1,
-                additionalArgs: 0.1
-            }))
-            .addOperation(new L.DNC.TurfOperation('union', {
-                minFeatures: 2,
-                maxFeatures: 2
-            }))
-            .addOperation(new L.DNC.TurfOperation('erase', {
-                minFeatures: 2,
-                maxFeatures: 2
-            }))
-            ;
+    // Append this domElement to a give domElement
+    addTo: function ( parentDomElement ) {
+        parentDomElement.appendChild(this.domElement);
+        this.parentDomElement = parentDomElement;
+        return this;
+    },
 
-        this.menus = [];
-        this.menus.push( geotools );
+    // Create and return dom element
+    _buildDomElement: function () {
+        return document.createElement('div');
     }
 });

--- a/src/js/menu/operations/Operation.js
+++ b/src/js/menu/operations/Operation.js
@@ -1,15 +1,5 @@
 L.DNC = L.DNC || {};
-L.DNC.Operation = L.Class.extend({
-
-    options: {
-    },
-
-    initialize: function ( title, options ) {
-        L.setOptions(this, options);
-        this.title = title;
-        this.domElement = this._buildDomElement();
-        this._addEventHandlers();
-    },
+L.DNC.Operation = L.DNC.Menu.extend({
 
     _addEventHandlers : function () {
         this.domElement.addEventListener('click', function(){
@@ -17,7 +7,7 @@ L.DNC.Operation = L.Class.extend({
         }.bind(this));
     },
 
-    // Generate and return button
+    // Create and return dom element (note: this does not attach dom element to any parent)
     _buildDomElement: function () {
         var div = document.createElement('div');
         div.innerHTML += '<button class="menu-button menu-button-action" id="' +

--- a/src/sass/_nav.scss
+++ b/src/sass/_nav.scss
@@ -8,7 +8,6 @@
   left:250px;
   background:$white;
   padding:5px;
-  height:41px;
 }
 
 .menu {


### PR DESCRIPTION
As mentioned in #41, I felt that the menu configuration should be moved into `L.DNC.js`. This allows for all the classes within `menu/` to act as more flexible constructor pieces.  Additionally, I tried to adopt a pattern for the API `addTo`, `addChild`, as was used by the `LayerList` (well, `addTo` at least).

I wanted to get this in quick before we throw @hamhands for another loop.