### PR TITLE
Add continuous integration tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ before_install:
   - gem install sass
 before_script:
   - grunt build:basic
+after_success:
+  - .travis/deploy-to-gh-pages.sh
+env:
+  - RELEASE_BRANCH=master

--- a/.travis/deploy-to-gh-pages.sh
+++ b/.travis/deploy-to-gh-pages.sh
@@ -1,0 +1,28 @@
+# Post-build Deployment Script
+# Upon a successful build in the 'release branch', this script will set up Git
+# and the Grunt gh-pages command.
+#
+# This script requires:
+#   - that grunt-gh-pages be installed and configured: https://github.com/tschaub/grunt-gh-pages
+#   - a 'GH_TOKEN' environment variable representing a Github OAuth token with
+#     'public_repo' permissions be added. Note: Best practice is to store this
+#     as a non-visible variable within the Travis online settings rather than
+#     within .travis.yml
+#   - a 'RELEASE_BRANCH' environment variable representing the name of the
+#     branch to watch for commits. Can be added online or within .travis.yml
+#
+
+if [ "${TRAVIS_BRANCH}" != "${RELEASE_BRANCH}" ]; then
+    echo "In branch '${TRAVIS_BRANCH}', not '${RELEASE_BRANCH}'. Not deploying."
+    exit 0;
+fi
+
+echo "Configuring git..."
+git config --global user.email "travis@cugos.org"
+git config --global user.name "Travis CI"
+git remote set-url origin https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+
+echo "Running gh-pages..."
+grunt gh-pages || exit
+
+echo "Successfully deployed to gh-pages"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,12 @@ module.exports = function(grunt) {
       unit: {
           configFile: 'spec/karma.conf.js'
       }
+    },
+    'gh-pages': {
+      options: {
+        base: '.'
+      },
+      src: ['**']
     }
   });
 
@@ -78,6 +84,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-gh-pages');
   grunt.loadNpmTasks('grunt-karma');
 
   // Tasks.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/cugos/drop-n-chop.svg?branch=leaflet-plugin)](https://travis-ci.org/cugos/drop-n-chop)
+[![Build Status](https://travis-ci.org/cugos/drop-n-chop.svg?branch=master)](https://travis-ci.org/cugos/drop-n-chop)
 
 # Drop 'n Chop
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-gh-pages": "^0.10.0",
     "grunt-karma": "~0.10.1",
     "grunt-reload": "^0.2.0",
     "happen": "~0.1.3",


### PR DESCRIPTION
After a successful build, Travis will run `.travis/deploy-to-gh-pages.sh`. This script will check to see that the build took place on the `RELEASE_BRANCH` (configured as a variable within the Travis configuration file), and if it has [`grunt gh-pages`](https://github.com/tschaub/grunt-gh-pages) is ran, copying the repo (including ignored files/dirs, excluding dot files/dirs) to the `gh-pages` branch.  This requires that Travis have a [Github OAuth token] added as a variable (this is done as a hidden variable on the Travis website, rather than within the config file).  I've gone ahead and set Travis up with a token.

Currently, `RELEASE_BRANCH` is set as `master`, meaning any commits to `master` will be deployed. If this proves to be a source of error, we can adjust as necessary.

This addresses #38 