### PR TITLE
Clean up addChild()

### DIFF
--- a/src/js/menu/Menu.js
+++ b/src/js/menu/Menu.js
@@ -10,12 +10,9 @@ L.DNC.Menu = L.DNC.MenuBar.extend({
     },
 
     // Add object as child. Object must have domElement property.
-    addChild: function( child ) {
-        var dropdown = this.domElement.getElementsByClassName('menu-dropdown')[0];
-        dropdown.appendChild( child.domElement );
-        child.parent = this;
-        this.children.push( child );
-        return this;
+    addChild: function( child, target ) {
+        target = target || this.domElement.getElementsByClassName('menu-dropdown')[0];
+        return this.constructor.__super__.addChild.call(this, child, target);
     },
 
     // handlers for menu options

--- a/src/js/menu/MenuBar.js
+++ b/src/js/menu/MenuBar.js
@@ -3,28 +3,30 @@ L.DNC.MenuBar = L.Class.extend({
     includes: L.Mixin.Events,
 
     initialize: function ( options ) {
-        L.setOptions(this, options);
+        L.setOptions( this, options );
         this.children = [];
         this.domElement = this._buildDomElement();
     },
 
     // Add object as child. Object must have domElement property.
-    addChild: function ( child ) {
-        this.domElement.appendChild(child.domElement);
-        child.parentDomElement = this;
+    addChild: function ( child, target ) {
+        target = target || this.domElement;
+        target.appendChild( child.domElement );
+        child.parent = this;
         this.children.push( child );
         return this;
     },
 
-    // Append this domElement to a give domElement
-    addTo: function ( parentDomElement ) {
-        parentDomElement.appendChild(this.domElement);
-        this.parentDomElement = parentDomElement;
+    // Append this domElement to a give parent object's dom element
+    addTo: function ( parent ) {
+        var parentDomElement = parent.domElement || parent; // If parent doesn't have a domElement, assume that it IS a dom element
+        parentDomElement.appendChild( this.domElement );
+        this.parent = parent;
         return this;
     },
 
     // Create and return dom element
     _buildDomElement: function () {
-        return document.createElement('div');
+        return document.createElement( 'div' );
     }
 });

--- a/src/js/menu/operations/TurfOperation.js
+++ b/src/js/menu/operations/TurfOperation.js
@@ -46,7 +46,7 @@ L.DNC.TurfOperation = L.DNC.Operation.extend({
         **
         */
         var eventExtras = { mapLayer: mapLayer, layerName: newLayer.name, isOverlay: true };
-        this.parent.parentDomElement.fire('operation-result', eventExtras);
+        this.parent.parent.fire('operation-result', eventExtras);
     },
 
     _validate: function ( layers ) {


### PR DESCRIPTION
Two changes:
- **Rely on inheritance for `addChild()`**: Rather than have `L.DNC.Menu.addChild()` duplicate the functionality of its parent's `addChild()` with a small change, it now makes the change and calls the parent's `addChild()`.  Not sure how you guys feel on inheritance-heavy OO design, it can make it difficult to figure out where methods and attributes are coming from, but can prevent a lot of rewritten code.  Maybe we should make `Operation`, `TurfOperation`, `Menu`, and `MenuBars` all inherit for L.Class but pick and choose from a collection of mixins?  This could make things a bit cleaner.
- **Simplify `parent` vs `parentDomElement`**: For some reason, `Operation`, `TurfOperation`, `Menu`, and `MenuBars` were creating attributes called `parentDomElement` that were sometimes a dom elements but were usually objects. Now, when the parent will always be an object if possible.  If the parent is an actual domElement (such as when appending the `MenuBar` to empty `nav#menu-bar`
">`), then the domElement is appended as `parent` (maybe this is wrong? maybe it should be a different attr? I kind of liked it being the same)