### PR TITLE
Baselayer switcher

### DIFF
--- a/src/js/mapview/MapView.js
+++ b/src/js/mapview/MapView.js
@@ -25,9 +25,23 @@ L.DNC.MapView = L.Class.extend({
     _setupMap : function () {
 
         L.mapbox.accessToken = 'pk.eyJ1Ijoic3ZtYXR0aGV3cyIsImEiOiJVMUlUR0xrIn0.NweS_AttjswtN5wRuWCSNA';
-        this._map = L.mapbox.map('map', 'examples.map-zr0njcqy', {
+        this._map = L.mapbox.map('map', null, {
             zoomControl: false
         }).setView([0,0], 3);
+
+        var baseLayers = {
+            "Mapbox Streets": L.mapbox.tileLayer('mapbox.streets'),
+            "Mapbox Outdoors": L.mapbox.tileLayer('mapbox.outdoors'),
+            "Mapbox Light": L.mapbox.tileLayer('mapbox.light'),
+            "Mapbox Dark": L.mapbox.tileLayer('mapbox.dark'),
+            "Mapbox Satellite": L.mapbox.tileLayer('mapbox.satellite')
+        };
+
+        baseLayers['Mapbox Streets'].addTo(this._map);
+        L.control.layers(baseLayers, {}, {
+            position: 'bottomright',
+            collapsed: false
+        }).addTo(this._map);
 
     }
 


### PR DESCRIPTION
- Adds a baselayer switcher to switch between:
  - Mapbox Streets (default)
  - Mapbox Outdoors
  - Mapbox Light
  - Mapbox Dark
  - Mapbox Satellite
- Adds control for baselayer switching to bottom right, not collapsed

The idea here is to be able to add custom layers with custom map IDs in the future, but this is just a start / proof of concept.