### PR TITLE
revert back to 2.0.0

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <head>
   <title>Drip. Drop. Drip.</title>
 
-  <script src="//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.2/turf.min.js"></script>
+  <script src="//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js"></script>
   <script src="//api.tiles.mapbox.com/mapbox.js/v2.1.9/mapbox.js"></script>
 
   <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">


### PR DESCRIPTION
From #69 it looks like the [Turf CDN](https://www.mapbox.com/mapbox.js/plugins/) hasn't been updated to match the [current Turf version](https://github.com/Turfjs/turf/commit/ab4c54a8abbcd333a5678e09b485dd9a55f2d874). Going to revert the library to 2.0.0 for the time being. I should have caught this in the PR. Sorry @lyzidiamond!