### PR TITLE
Simplify menu methods

### DIFF
--- a/spec/suites/L.DNC.Menu.js
+++ b/spec/suites/L.DNC.Menu.js
@@ -21,7 +21,7 @@ describe("L.DNC.Menu", function () {
 
 
     beforeEach(function () {
-        menu = new L.DNC.Menu( title, parent, fakeOptions );
+        menu = new L.DNC.Menu( title, fakeOptions ).addTo( parent );
     });
 
 
@@ -120,7 +120,7 @@ describe("L.DNC.Menu", function () {
 
         it("unexpands one menu when other menu is clicked", function () {
             // Setup
-            var menu2 = new L.DNC.Menu( "Second Menu", parent, fakeOptions );
+            var menu2 = new L.DNC.Menu( "Second Menu", fakeOptions ).addTo( parent );
             var dropdown2 = menu2.domElement.getElementsByClassName('menu-dropdown')[0];
             document.body.appendChild(menu.domElement);
             document.body.appendChild(menu2.domElement);

--- a/spec/suites/L.DNC.Menu.js
+++ b/spec/suites/L.DNC.Menu.js
@@ -92,36 +92,6 @@ describe("L.DNC.Menu", function () {
 
     /*
     **
-    **  No longer using .addChild() in the code so going to 
-    **  keep this one commented out for now
-    **
-    */
-    describe("public methods", function (){
-
-        // it("has addTo", function () {
-        //     expect( menu.addTo ).to.be.ok;
-
-        //     var parent = document.createElement( 'div' );
-        //     menu.addTo(parent);
-
-        //     expect( parent.outerHTML ).to.equal( '<div>' + expected_html + '</div>' );
-        // });
-
-        // it("has addChild", function () {
-        //     expect( menu.addChild ).to.be.ok;
-
-        //     var child = document.createElement( 'div' );
-        //     var innerHtml = "<b>This is probably where a button would be</b>";
-
-        //     child.innerHTML = innerHtml;
-        //     menu.addChild( { domElement: child } );
-        //     expect( menu.domElement.outerHTML ).to.equal( begin_html + child.outerHTML + end_html );
-        // });
-
-    });
-
-    /*
-    **
     **  Testing the dropdown/visibility functionality for menus.
     **  Create a second menu to test for menu closing when another
     **  has been clicked.

--- a/src/js/controller/AppController.js
+++ b/src/js/controller/AppController.js
@@ -16,13 +16,13 @@ L.DNC.AppController = L.Class.extend({
         this.dropzone = new L.DNC.DropZone( this.mapView._map, {} );
         this.layerlist = new L.DNC.LayerList( { layerContainerId: 'dropzone' } ).addTo( this.mapView._map );
 
-        this.menubar = new L.DNC.MenuBar( { id: 'menu-bar' } );
+        this.menubar = new L.DNC.MenuBar( { id: 'menu-bar' } ).addTo( document.body );
 
         // new menu
         this.menu = {
-            geo: new L.DNC.Menu('Geoprocessing', this.menubar, {
+            geo: new L.DNC.Menu('Geoprocessing', {
                 items: ['buffer', 'union']
-            })
+            }).addTo( this.menubar )
         };
 
         this.ops = {

--- a/src/js/menus/Menu.js
+++ b/src/js/menus/Menu.js
@@ -2,10 +2,9 @@ L.DNC = L.DNC || {};
 L.DNC.Menu = L.Class.extend({
     includes: L.Mixin.Events,
 
-    initialize: function ( title, parent, options ) {
+    initialize: function ( title, options ) {
         L.setOptions(this, options);
         this.title = title;
-        this.parent = parent;
         this.children = this._buildMenuItems(this.options.items);
         this.domElement = this._buildDomElement(this.children);
         this._addEventHandlers();
@@ -50,6 +49,18 @@ L.DNC.Menu = L.Class.extend({
         }
     },
 
+    /*
+    **
+    ** Append this domElement to a give parent object's dom element
+    **
+    */
+    addTo: function ( parent ) {
+        var parentDomElement = parent.domElement || parent; // If parent doesn't have a domElement, assume that it IS a dom element
+        parentDomElement.appendChild( this.domElement );
+        this.parent = parent;
+        return this;
+    },
+
     _buildMenuItems: function ( items ) {
         var tempArray = [];
         for ( var i = 0; i < items.length; i++ ) {
@@ -75,7 +86,6 @@ L.DNC.Menu = L.Class.extend({
         }
 
         menu.appendChild(menuDropdown);
-        this.parent.domElement.appendChild(menu); // add to DOM
         return menu;
     }
 });

--- a/src/js/menus/Menu.js
+++ b/src/js/menus/Menu.js
@@ -11,12 +11,6 @@ L.DNC.Menu = L.Class.extend({
         this._addEventHandlers();
     },
 
-    // Add object as child. Object must have domElement property.
-    addChild: function( child, target ) {
-        target = target || this.domElement.getElementsByClassName('menu-dropdown')[0];
-        return this.constructor.__super__.addChild.call(this, child, target);
-    },
-
     // handlers for menu options
     _addEventHandlers : function () {
 

--- a/src/js/menus/MenuBar.js
+++ b/src/js/menus/MenuBar.js
@@ -5,7 +5,7 @@ L.DNC.MenuBar = L.Class.extend({
     initialize: function ( options ) {
         L.setOptions( this, options );
         this.children = [];
-        this.domElement = this._buildDomElement();
+        this.domElement = this._buildDomElement(this.options.id);
     },
 
     // Append this domElement to a give parent object's dom element
@@ -21,10 +21,9 @@ L.DNC.MenuBar = L.Class.extend({
     ** create the DOM element #menu-bar
     **
     */
-    _buildDomElement: function () {
+    _buildDomElement: function ( id ) {
         var nav = document.createElement('nav');
-        nav.id = this.options.id;
-        document.body.appendChild(nav);
+        nav.id = id;
         return nav;
     }
 });

--- a/src/js/menus/MenuBar.js
+++ b/src/js/menus/MenuBar.js
@@ -8,15 +8,6 @@ L.DNC.MenuBar = L.Class.extend({
         this.domElement = this._buildDomElement();
     },
 
-    // Add object as child. Object must have domElement property.
-    addChild: function ( child, target ) {
-        target = target || this.domElement;
-        target.appendChild( child.domElement );
-        child.parent = this;
-        this.children.push( child );
-        return this;
-    },
-
     // Append this domElement to a give parent object's dom element
     addTo: function ( parent ) {
         var parentDomElement = parent.domElement || parent; // If parent doesn't have a domElement, assume that it IS a dom element

--- a/src/js/menus/MenuBar.js
+++ b/src/js/menus/MenuBar.js
@@ -8,7 +8,11 @@ L.DNC.MenuBar = L.Class.extend({
         this.domElement = this._buildDomElement(this.options.id);
     },
 
-    // Append this domElement to a give parent object's dom element
+    /*
+    **
+    ** Append this domElement to a give parent object's dom element
+    **
+    */
     addTo: function ( parent ) {
         var parentDomElement = parent.domElement || parent; // If parent doesn't have a domElement, assume that it IS a dom element
         parentDomElement.appendChild( this.domElement );


### PR DESCRIPTION
- Remove unused `addChild` code.
- In the spirit of keeping functions more simple and single-purpose, when `Menu` / `MenuBar` objects are instantiated, they do not implicitly add themselves to their parent objects.  This is now handled by their `addTo()` methods (similar to how you must `.addTo(map)` layers with Leaflet).  
