### PR TITLE
Refactor the way operations are bound to menu items

### DIFF
--- a/src/js/controller/AppController.js
+++ b/src/js/controller/AppController.js
@@ -24,16 +24,16 @@ L.DNC.AppController = L.Class.extend({
 
         this.menubar = new L.DNC.MenuBar( { id: 'menu-bar' } ).addTo( document.body );
 
-        // new menu
-        this.menu = {
-            geo: new L.DNC.Menu('Geoprocessing', {
-                items: ['buffer', 'union']
-            }).addTo( this.menubar )
+        // build out menus
+        this.menus = {
+            geo: new L.DNC.Menu('Geoprocessing', {  // New dropdown menu
+                items: ['buffer', 'union']          // Items in menu
+            }).addTo( this.menubar )                // Append to menubar
         };
 
-        this.ops = {
-            geo: new L.DNC.Geo(),
-            geox: new L.DNC.GeoExecute()
+        this.geoOpsConfig = {
+            operations: new L.DNC.Geo(),        // Configurations of GeoOperations
+            executor: new L.DNC.GeoExecute()    // Executor of GeoOperations
         };
 
         this.forms = new L.DNC.Forms();
@@ -45,18 +45,21 @@ L.DNC.AppController = L.Class.extend({
 
     _addEventHandlers: function(){
         this.dropzone.fileReader.on( 'fileparsed', this._handleParsedFile.bind( this ) );
-        this.forms.on( 'submit', this._handleFormSubmit.bind(this) );
-        this.menu.geo.on( 'clickedOperation', this._handleGeoClick.bind(this) );
+
+        // Handle clicks on items within geoMenu
+        // NOTE: This is where an operation is tied to a menu item
+        this.menus.geo.on( 'clickedOperation', this._handleOperationClick.bind( this, this.geoOpsConfig ) );
     },
 
     /*
     **
-    ** Lookup geo operation from clicked geomenu item, render appropriate form
+    ** Lookup operation by name from operations configuration, render appropriate form
     **
     */
-    _handleGeoClick: function( e ) {
-        var info = this.ops.geo[e.action];
-        this.forms.render( e.action, info );
+    _handleOperationClick: function( opsConfig, e ) {
+        var config = opsConfig.operations[e.action];
+        var form = this.forms.render( e.action, config );
+        form.on( 'submit', this._handleFormSubmit.bind( this, opsConfig ) );
     },
 
     /*
@@ -64,16 +67,18 @@ L.DNC.AppController = L.Class.extend({
     ** Take input from an options form, use input to execute operation, get new
     ** layer, pass new layer off to be added to map.
     **
+    ** TODO: This is currently only built to handle geo operations. Eventually,
+    ** we'll need to support operations that don't return geo layers.
+    **
     */
-    _handleFormSubmit: function( e ) {
-
-        var newLayer = this.ops.geox.execute(
+    _handleFormSubmit: function( opsConfig, e ) {
+        var newLayer = opsConfig.executor.execute(
             e.action,
             e.parameters,
-            this.ops.geo[e.action],
+            opsConfig.operations[e.action],
             this.getLayerSelection()
         );
-        this._handleGeoResult(layer);
+        this._handleGeoResult(newLayer);
     },
 
     /*
@@ -101,10 +106,6 @@ L.DNC.AppController = L.Class.extend({
     _handleGeoResult: function( layer ) {
         var mapLayer = L.mapbox.featureLayer( layer.geometry );
         this.layerlist.addLayerToList( mapLayer, layer.name, true );
-    },
-
-    _handleOperationClick: function ( e ) {
-        this.forms.render( e );
     },
 
     getLayerSelection: function(){

--- a/src/js/controller/AppController.js
+++ b/src/js/controller/AppController.js
@@ -67,18 +67,18 @@ L.DNC.AppController = L.Class.extend({
     ** Take input from an options form, use input to execute operation, get new
     ** layer, pass new layer off to be added to map.
     **
-    ** TODO: This is currently only built to handle geo operations. Eventually,
-    ** we'll need to support operations that don't return geo layers.
-    **
     */
     _handleFormSubmit: function( opsConfig, e ) {
+        var config = opsConfig.operations[e.action];
         var newLayer = opsConfig.executor.execute(
             e.action,
             e.parameters,
-            opsConfig.operations[e.action],
+            config,
             this.getLayerSelection()
         );
-        this._handleGeoResult(newLayer);
+        if (config.createsLayer) {
+            this._handleGeoResult(newLayer);
+        }
     },
 
     /*

--- a/src/js/forms/Forms.js
+++ b/src/js/forms/Forms.js
@@ -26,9 +26,9 @@ L.DNC.Forms = L.Class.extend({
 
             for ( var i = 0; i < this.options.parameters.length; i++ ) {
                 var parameter = this.options.parameters[i];
-                
+
                 var input = '<div class="parameter"><label class="parameter-name">' + parameter.name + '</label>';
-                
+
                 // select
                 if ( parameter.type == 'select') {
                     input += this._inputTypeSelect( parameter );
@@ -43,7 +43,7 @@ L.DNC.Forms = L.Class.extend({
 
         }
 
-        // submit button 
+        // submit button
         html += '<button type="button" class="btn form-submit" id="operation-submit">Execute<i class="fa fa-thumbs-o-up push-left"></i></button>';
         html += '</div></div>';
 
@@ -52,8 +52,11 @@ L.DNC.Forms = L.Class.extend({
         div.id = 'DNC-FORM';
         div.innerHTML = html;
         document.body.appendChild(div);
+        this.domElement = div;
 
-        this._formHandlers();
+        this._formHandlers(div);
+
+        return this;
     },
 
     closeForm: function ( event ) {
@@ -86,7 +89,7 @@ L.DNC.Forms = L.Class.extend({
             this.fire( 'submit', { action: this.title, parameters: this.paramArray } );
             this.closeForm();
         }
-        
+
 
     },
 

--- a/src/js/forms/Forms.js
+++ b/src/js/forms/Forms.js
@@ -64,7 +64,7 @@ L.DNC.Forms = L.Class.extend({
         child.parentElement.removeChild(child);
     },
 
-    submitForm: function() {
+    submitForm: function( e ) {
         // function that grabs all parameter information from the
         // current open form, and publishes 'form-submitted' so the
         // operations subscriber can execute the turf operation
@@ -88,6 +88,9 @@ L.DNC.Forms = L.Class.extend({
         if ( this.validateForm() ) {
             this.fire( 'submit', { action: this.title, parameters: this.paramArray } );
             this.closeForm();
+
+            // Remove event listener
+            this._leaflet_events.submit = []; // TODO: There's surely a better way to do this
         }
 
 

--- a/src/js/operations/Geo.js
+++ b/src/js/operations/Geo.js
@@ -21,13 +21,15 @@ L.DNC.Geo = L.Class.extend({
                 options: ['miles', 'feet', 'kilometers', 'meters', 'degrees'],
                 default: 'miles'
             }
-        ]
+        ],
+        createsLayer: true
     },
 
     union: {
         minFeatures: 2,
         maxFeatures: 2,
-        description: 'Takes two polygons and returns a combined polygon. If the input polygons are not contiguous, this function returns a MultiPolygon feature.'
+        description: 'Takes two polygons and returns a combined polygon. If the input polygons are not contiguous, this function returns a MultiPolygon feature.',
+        createsLayer: true
     }
 
 });

--- a/src/js/operations/GeoExecute.js
+++ b/src/js/operations/GeoExecute.js
@@ -22,7 +22,7 @@ L.DNC.GeoExecute = L.Class.extend({
         **  do it there anyways.
         **
         **/
-        // this._validate(layers);
+        this.validate(layers, options);
 
         // Prep
         var params = this._prepareParameters( layers, options, parameters );
@@ -53,18 +53,27 @@ L.DNC.GeoExecute = L.Class.extend({
     **  allow Turf operations to run
     **
     */
-    _validate: function ( layers ) {
+    validate: function ( layers, options ) {
         var length = layers.length;
+
+        // TODO: This should live elsewhere
+        function ValidationError(message) {
+              this.name = 'ValidationError';
+              this.message = message || 'Validation Error';
+        }
+        ValidationError.prototype = Object.create(Error.prototype);
+        ValidationError.prototype.constructor = ValidationError;
+
         if (!length) {
-            throw new Error("Can't run " + this.title + " on empty selection.");
+            throw new ValidationError("Can't run " + this.title + " on empty selection.");
         }
 
-        if (this.options.maxFeatures && length > this.options.maxFeatures) {
-            throw new Error("Too many layers. Max is set to " + this.options.maxFeatures + ", got " + length + ".");
+        if (options.maxFeatures && length > options.maxFeatures) {
+            throw new ValidationError("Too many layers. Max is set to " + options.maxFeatures + ", got " + length + ".");
         }
 
-        if (this.options.minFeatures && length < this.options.minFeatures) {
-            throw new Error("Too few layers. Min is set to " + this.options.minFeatures + ", got " + length + ".");
+        if (options.minFeatures && length < options.minFeatures) {
+            throw new ValidationError("Too few layers. Min is set to " + options.minFeatures + ", got " + length + ".");
         }
     },
 
@@ -76,8 +85,8 @@ L.DNC.GeoExecute = L.Class.extend({
     **
     */
     _prepareParameters: function ( layers, options, params ) {
-        if (this.options.maxFeatures) {
-            layers = layers.slice(0, this.options.maxFeatures);
+        if (options.maxFeatures) {
+            layers = layers.slice(0, options.maxFeatures);
         }
         var layer_objs = layers.map(function(obj) { return obj.layer._geojson; });
         console.debug(layer_objs, params);

--- a/src/js/operations/GeoExecute.js
+++ b/src/js/operations/GeoExecute.js
@@ -14,16 +14,6 @@ L.DNC.GeoExecute = L.Class.extend({
         L.setOptions(this, options);
         this.action = action;
 
-        /*
-        **
-        **  TODO: I think validation should happen before the
-        **  submit form is rendered on the DOM. If we plan to
-        **  only show available operations then we'll have to
-        **  do it there anyways.
-        **
-        **/
-        this.validate(layers, options);
-
         // Prep
         var params = this._prepareParameters( layers, options, parameters );
         var name = this._prepareName( layers );


### PR DESCRIPTION
# What changed...

## Refactor operations
Prior to this code change, `L.DNC.AppController._handleFormSubmit()` assumed that all form submits were `L.DNC.Geo` operations (defined within `this.ops.geo`) to be executed by `L.DNC.GeoExecute` (defined within `this.ops.geox`).  Many future operations will not be geo operations (such as 'Save').  This is an effort to break that restriction by allowing the handlers of `clickedOperation` to be configured when the signal is attached.

To distinguish between handling results of geo-operations and non-geo-operations, a `createsLayer` property has been added to all geo-operations.  This should hopefully play nicely with #80.

## Add validation BEFORE forms appear
Operations are now validated before forms are rendered.  Errors will appear via notification.

## Bugfix: Prevent multiple layer being generated
A new listener to `submit` was being attached to a form every time a form was rendered. These listeners persist between forms, causing multiple layers to be generated on a single operation.  A hacky fix was added to clear listeners after the form is submitted.  This may fix #64. Not sure.